### PR TITLE
Fix lint errors

### DIFF
--- a/cmd/delete_merged_branch.go
+++ b/cmd/delete_merged_branch.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// deleteMergedBranchCmd represents the deleteMergedBranch command
+// deleteMergedBranchCmd represents the deleteMergedBranch command.
 var deleteMergedBranchCmd = &cobra.Command{
 	Use:     "delete-merged-branch",
 	Aliases: []string{"mergedd"},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
+// rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "git-auto",
 	Short: "Auto git commands",

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -10,13 +10,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// tagCmd represents the tag command
+// tagCmd represents the tag command.
 var tagCmd = &cobra.Command{
 	Use:   "tag [<version>] [major|minor|patch]",
 	Short: "Auto increment tag version",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		isPush, _ := cmd.Flags().GetBool("push")
-		msg, _ := cmd.Flags().GetString("message")
+		isPush, err := cmd.Flags().GetBool("push")
+		if err != nil {
+			return err
+		}
+
+		msg, err := cmd.Flags().GetString("message")
+		if err != nil {
+			return err
+		}
 
 		if len(args) == 0 {
 			return errors.New("not found argument")
@@ -25,7 +32,7 @@ var tagCmd = &cobra.Command{
 		target := args[0]
 
 		u := usecase.NewGitUsecase()
-		_, err := u.VersionUp(target, msg, isPush)
+		_, err = u.VersionUp(target, msg, isPush)
 		if err != nil {
 			return err
 		}

--- a/usecase/doc.go
+++ b/usecase/doc.go
@@ -1,0 +1,2 @@
+// Package usecase provides git helper functions.
+package usecase

--- a/usecase/git_test.go
+++ b/usecase/git_test.go
@@ -1,8 +1,17 @@
 package usecase
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	versionBase       = "1.1.1"
+	versionBasePrefix = "v1.1.1"
+	versionMajor      = "major"
+	versionMinor      = "minor"
+	versionPatch      = "patch"
 )
 
 func TestTagVersionUp(t *testing.T) {
@@ -14,40 +23,40 @@ func TestTagVersionUp(t *testing.T) {
 	var version string
 	var err error
 
-	tag = "1.1.1"
-	target = "major"
+	tag = versionBase
+	target = versionMajor
 	version, err = tagVersionUp(tag, target)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, "2.0.0", version)
 
-	tag = "1.1.1"
-	target = "minor"
+	tag = versionBase
+	target = versionMinor
 	version, err = tagVersionUp(tag, target)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, "1.2.0", version)
 
-	tag = "1.1.1"
-	target = "patch"
+	tag = versionBase
+	target = versionPatch
 	version, err = tagVersionUp(tag, target)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, "1.1.2", version)
 
-	tag = "v1.1.1"
-	target = "patch"
+	tag = versionBasePrefix
+	target = versionPatch
 	version, err = tagVersionUp(tag, target)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, "v1.1.2", version)
 
-	tag = "v1.1.1aaa"
-	target = "patch"
+	tag = versionBasePrefix + "aaa"
+	target = versionPatch
 	_, err = tagVersionUp(tag, target)
 	if err == nil {
 		t.Fatal("error")
@@ -58,11 +67,11 @@ func TestCheckVersionPrefix(t *testing.T) {
 	var u gitUsecase
 	var checkVersionPrefix = (u).checkVersionPrefix
 
-	version := "v1.1.1"
+	version := versionBasePrefix
 	check := checkVersionPrefix(version)
 	assert.Equal(t, true, check)
 
-	version = "1.1.1"
+	version = versionBase
 	check = checkVersionPrefix(version)
 	assert.Equal(t, false, check)
 }
@@ -70,7 +79,7 @@ func TestCheckVersionPrefix(t *testing.T) {
 func TestIgnoreVersionPrefix(t *testing.T) {
 	var u gitUsecase
 
-	version := "v1.1.1"
+	version := versionBasePrefix
 	var getIgnoreVersionPrefix = (u).getIgnoreVersionPrefix
 	version = getIgnoreVersionPrefix(version)
 	assert.Equal(t, "1.1.1", version)
@@ -84,24 +93,24 @@ func TestIncrementVersion(t *testing.T) {
 	var target string
 	var err error
 
-	version = "1.1.1"
-	target = "major"
+	version = versionBase
+	target = versionMajor
 	version, err = incrementVersion(version, target)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, "2.0.0", version)
 
-	version = "1.1.1"
-	target = "minor"
+	version = versionBase
+	target = versionMinor
 	version, err = incrementVersion(version, target)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, "1.2.0", version)
 
-	version = "1.1.1"
-	target = "patch"
+	version = versionBase
+	target = versionPatch
 	version, err = incrementVersion(version, target)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- clean up comments and function params
- handle errors from os, strconv, and flags
- add doc.go
- use strings.ReplaceAll and other linter fixes
- add constants in tests

## Testing
- `golangci-lint run ./...`
- `go test ./... -v`
- `mise run go-test-all` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68453d25b718832abd4342ebe15995e0