### PR TITLE
feat: add constants for tag targets

### DIFF
--- a/usecase/constants.go
+++ b/usecase/constants.go
@@ -1,0 +1,7 @@
+package usecase
+
+const (
+	VersionMajor = "major"
+	VersionMinor = "minor"
+	VersionPatch = "patch"
+)

--- a/usecase/git.go
+++ b/usecase/git.go
@@ -26,7 +26,7 @@ func (u *gitUsecase) VersionUp(target, tagMsg string, isPush bool) (string, erro
 	var err error
 
 	switch target {
-	case "major", "minor", "patch":
+	case VersionMajor, VersionMinor, VersionPatch:
 		var tag string
 		tag, err = u.getCurrentTag()
 		if err != nil {
@@ -228,7 +228,7 @@ func (u *gitUsecase) incrementVersion(version, target string) (string, error) {
 	}
 
 	switch target {
-	case "major":
+	case VersionMajor:
 		num, err := strconv.Atoi(versions[0])
 		if err != nil {
 			return "", err
@@ -236,14 +236,14 @@ func (u *gitUsecase) incrementVersion(version, target string) (string, error) {
 		versions[0] = strconv.Itoa(num + 1)
 		versions[1] = "0"
 		versions[2] = "0"
-	case "minor":
+	case VersionMinor:
 		num, err := strconv.Atoi(versions[1])
 		if err != nil {
 			return "", err
 		}
 		versions[1] = strconv.Itoa(num + 1)
 		versions[2] = "0"
-	case "patch":
+	case VersionPatch:
 		num, err := strconv.Atoi(versions[2])
 		if err != nil {
 			return "", err

--- a/usecase/git_test.go
+++ b/usecase/git_test.go
@@ -9,9 +9,6 @@ import (
 const (
 	versionBase       = "1.1.1"
 	versionBasePrefix = "v1.1.1"
-	versionMajor      = "major"
-	versionMinor      = "minor"
-	versionPatch      = "patch"
 )
 
 func TestTagVersionUp(t *testing.T) {
@@ -24,7 +21,7 @@ func TestTagVersionUp(t *testing.T) {
 	var err error
 
 	tag = versionBase
-	target = versionMajor
+	target = VersionMajor
 	version, err = tagVersionUp(tag, target)
 	if err != nil {
 		t.Fatal(err)
@@ -32,7 +29,7 @@ func TestTagVersionUp(t *testing.T) {
 	assert.Equal(t, "2.0.0", version)
 
 	tag = versionBase
-	target = versionMinor
+	target = VersionMinor
 	version, err = tagVersionUp(tag, target)
 	if err != nil {
 		t.Fatal(err)
@@ -40,7 +37,7 @@ func TestTagVersionUp(t *testing.T) {
 	assert.Equal(t, "1.2.0", version)
 
 	tag = versionBase
-	target = versionPatch
+	target = VersionPatch
 	version, err = tagVersionUp(tag, target)
 	if err != nil {
 		t.Fatal(err)
@@ -48,7 +45,7 @@ func TestTagVersionUp(t *testing.T) {
 	assert.Equal(t, "1.1.2", version)
 
 	tag = versionBasePrefix
-	target = versionPatch
+	target = VersionPatch
 	version, err = tagVersionUp(tag, target)
 	if err != nil {
 		t.Fatal(err)
@@ -56,7 +53,7 @@ func TestTagVersionUp(t *testing.T) {
 	assert.Equal(t, "v1.1.2", version)
 
 	tag = versionBasePrefix + "aaa"
-	target = versionPatch
+	target = VersionPatch
 	_, err = tagVersionUp(tag, target)
 	if err == nil {
 		t.Fatal("error")
@@ -94,7 +91,7 @@ func TestIncrementVersion(t *testing.T) {
 	var err error
 
 	version = versionBase
-	target = versionMajor
+	target = VersionMajor
 	version, err = incrementVersion(version, target)
 	if err != nil {
 		t.Fatal(err)
@@ -102,7 +99,7 @@ func TestIncrementVersion(t *testing.T) {
 	assert.Equal(t, "2.0.0", version)
 
 	version = versionBase
-	target = versionMinor
+	target = VersionMinor
 	version, err = incrementVersion(version, target)
 	if err != nil {
 		t.Fatal(err)
@@ -110,7 +107,7 @@ func TestIncrementVersion(t *testing.T) {
 	assert.Equal(t, "1.2.0", version)
 
 	version = versionBase
-	target = versionPatch
+	target = VersionPatch
 	version, err = incrementVersion(version, target)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- define constants for tag versions
- use them in tag increment logic
- update tests to use new constants

## Testing
- `golangci-lint run ./...`
- `go test ./... -v`
- `mise run go-test-all` *(fails: go backend is experimental)*

------
https://chatgpt.com/codex/tasks/task_e_6845ad167338832a9967c386d23fb9a5