### PR TITLE
Fix integration test branch assumption

### DIFF
--- a/usecase/git_integration_test.go
+++ b/usecase/git_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -100,6 +101,12 @@ func TestDeleteMergedBranchesIntegration(t *testing.T) {
 	}
 
 	// create branch and merge
+	defaultBranchBytes, err := exec.Command("git", "branch", "--show-current").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultBranch := strings.TrimSpace(string(defaultBranchBytes))
+
 	if gitErr := gitCmd(dir, "checkout", "-b", "feature"); gitErr != nil {
 		t.Fatal(gitErr)
 	}
@@ -112,7 +119,7 @@ func TestDeleteMergedBranchesIntegration(t *testing.T) {
 	if gitErr := gitCmd(dir, "commit", "-m", "feature"); gitErr != nil {
 		t.Fatal(gitErr)
 	}
-	if gitErr := gitCmd(dir, "checkout", "master"); gitErr != nil {
+	if gitErr := gitCmd(dir, "checkout", defaultBranch); gitErr != nil {
 		t.Fatal(gitErr)
 	}
 	if gitErr := gitCmd(dir, "merge", "feature"); gitErr != nil {


### PR DESCRIPTION
## Summary
- handle default branch in TestDeleteMergedBranchesIntegration so that it works whether the repo uses `main` or `master`

## Testing
- `golangci-lint run ./...`
- `INTEGRATION_TEST=true go test -count=1 ./... -cover`


------
https://chatgpt.com/codex/tasks/task_e_6845bd2e93f0832a81b4af3dfddea2e5