### PR TITLE
change env var to constant

### DIFF
--- a/usecase/git_integration_test.go
+++ b/usecase/git_integration_test.go
@@ -9,7 +9,10 @@ import (
 	"testing"
 )
 
-const integrationEnv = "true"
+const (
+	integrationEnv    = "true"
+	integrationEnvVar = "INTEGRATION_TEST"
+)
 
 func gitCmd(dir string, args ...string) error {
 	cmd := exec.Command("git", args...)
@@ -53,7 +56,7 @@ func setupRepo(t *testing.T) (func(), string) {
 }
 
 func TestVersionUpIntegration(t *testing.T) {
-	if os.Getenv("INTEGRATION_TEST") != integrationEnv {
+	if os.Getenv(integrationEnvVar) != integrationEnv {
 		t.Skip("integration test")
 	}
 	cleanup, dir := setupRepo(t)
@@ -86,7 +89,7 @@ func TestVersionUpIntegration(t *testing.T) {
 }
 
 func TestDeleteMergedBranchesIntegration(t *testing.T) {
-	if os.Getenv("INTEGRATION_TEST") != integrationEnv {
+	if os.Getenv(integrationEnvVar) != integrationEnv {
 		t.Skip("integration test")
 	}
 	cleanup, dir := setupRepo(t)
@@ -140,7 +143,7 @@ func TestDeleteMergedBranchesIntegration(t *testing.T) {
 }
 
 func TestVersionUpPushIntegration(t *testing.T) {
-	if os.Getenv("INTEGRATION_TEST") != integrationEnv {
+	if os.Getenv(integrationEnvVar) != integrationEnv {
 		t.Skip("integration test")
 	}
 


### PR DESCRIPTION
## Summary
- use a constant for the `INTEGRATION_TEST` environment variable in integration tests

## Testing
- `go test ./... -v`
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_68465a46d144832a980027b7a959b071