### PR TITLE
feat: embed version info via ldflags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,9 @@ builds:
     ldflags:
       - -s
       - -w
+      - -X github.com/s-matsubara/git-auto/cmd.Version={{ .Version }}
+      - -X github.com/s-matsubara/git-auto/cmd.Commit={{ .ShortCommit }}
+      - -X github.com/s-matsubara/git-auto/cmd.BuildDate={{ .Date }}
 
 universal_binaries:
   - replace: true


### PR DESCRIPTION
## Summary
- inject version details using GoReleaser ldflags

## Testing
- `golangci-lint run ./...`
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_e_68465e0f5824832a8104684d0c4f8b55